### PR TITLE
Update to latest alpine version (3.20)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ COPY ["./entrypoint.sh", "/usr/local/bin/"]
 
 
 # Main image
-FROM alpine:3.15
+FROM alpine:3.20
 
 # http://wiki.linux-nfs.org/wiki/index.php/Nfsv4_configuration
 RUN set -eux \
-    && apk --update --no-cache add bash nfs-utils \
+    && apk --update --no-cache add libcap bash nfs-utils \
     && rm -rfv /etc/idmapd.conf /etc/exports \
     && mkdir -p /var/lib/nfs/rpc_pipefs \
     && mkdir -p /var/lib/nfs/v4recovery \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -530,7 +530,7 @@ boot_helper_mount() {
 boot_helper_get_version_flags() {
 
   local -r requested_version="${state[$STATE_NFS_VERSION]}"
-  local flags=('--nfs-version' "$requested_version" '--no-nfs-version' 2)
+  local flags=('--nfs-version' "$requested_version")
 
   if ! is_nfs3_enabled; then
     flags+=('--no-nfs-version' 3)


### PR DESCRIPTION
This commit removes the `--no-nfs-version 2` flag, which is no longer needed as newer versions of nfsd do not support NFS v2 anymore.
Additionally, it adds libcap to the docker image as it is no longer part of nfs-utils.

As mentioned in https://github.com/N0rthernL1ghts/docker-nfs-server/issues/3#issuecomment-2293430286, this is the fix that allows newer/current version of the alpine base image.